### PR TITLE
Add optional table name to csv sources

### DIFF
--- a/CSV_TABLE_NAMES_FEATURE.md
+++ b/CSV_TABLE_NAMES_FEATURE.md
@@ -1,0 +1,129 @@
+# CSV Sources with Custom Table Names Feature
+
+## Overview
+The application now supports loading CSV/TSV data sources with optional custom table names. When loading data into SQLite, you can specify the exact table name to use, or let the system automatically generate one from the filename.
+
+## Configuration
+
+### csvSources.js Structure
+Each data source in the `fileSources` array can have the following properties:
+
+```javascript
+{
+    url: 'https://example.com/data.csv',      // Required: URL of the CSV/TSV file
+    tableName: 'custom_name',                 // Optional: Custom table name for SQLite
+    type: 'csv'                               // Optional: 'csv' or 'tsv' (defaults to 'csv')
+}
+```
+
+### Examples
+
+1. **With custom table name:**
+```javascript
+{
+    url: 'https://raw.githubusercontent.com/datasets/country-codes/master/data/country-codes.csv',
+    tableName: 'countries',  // Will create table named 'countries' instead of 'country_codes'
+    type: 'csv'
+}
+```
+
+2. **Without custom table name (uses filename):**
+```javascript
+{
+    url: 'https://raw.githubusercontent.com/datasets/covid-19/master/data/countries-aggregated.csv'
+    // Will create table named 'countries_aggregated' (from filename)
+}
+```
+
+## How It Works
+
+1. **Table Name Generation:**
+   - If `tableName` is provided, it will be sanitized and used
+   - If not provided, the filename (without extension) is extracted from the URL and sanitized
+   - Special characters are replaced with underscores
+   - Names starting with numbers get 'table_' prefix
+   - Multiple underscores are condensed to single ones
+
+2. **Sanitization Rules:**
+   - `my-table-name!` becomes `my_table_name`
+   - `123data` becomes `table_123data`
+   - `my___table` becomes `my_table`
+
+## Usage
+
+### Switching Between Data Sources
+
+In `main.js`, you can switch between SQLite database and CSV sources:
+
+```javascript
+// Configuration: Set to 'sqlite' to load from SQLite DB, or 'csv' to load from CSV sources
+const dataSourceMode = 'csv'; // or 'sqlite'
+```
+
+### Testing the Feature
+
+1. **Run the test suite:**
+```bash
+npm test
+```
+
+2. **Test with real data:**
+   - Open `test-csv-sources.html` in a browser
+   - This loads real CSV data from GitHub datasets
+   - Shows how custom table names are applied
+
+3. **Use in production:**
+   - Open `index.html` 
+   - Set `dataSourceMode` to 'csv' in main.js
+   - Configure your sources in `csvSources.js`
+
+## API Functions
+
+### generateTableNameFromUrl(url, customTableName)
+Generates a sanitized table name from a URL or uses a custom name if provided.
+
+**Parameters:**
+- `url` (string): The URL to generate a table name from (used as fallback)
+- `customTableName` (string, optional): An optional custom table name
+
+**Returns:** 
+- (string) The sanitized table name
+
+### initializeDatabaseFromCSV(sources)
+Initializes the SQL.js database from CSV sources.
+
+**Parameters:**
+- `sources` (Array): Array of source configurations
+
+**Returns:** 
+- (Promise<SQL.Database>) The initialized SQL.js database instance
+
+### loadCSVSource(dbInstance, source)
+Loads CSV/TSV data from a source configuration into the database.
+
+**Parameters:**
+- `dbInstance` (SQL.Database): The initialized SQL.js database instance
+- `source` (Object): The source configuration object
+
+## Benefits
+
+1. **Flexibility:** Choose meaningful table names that make SQL queries more intuitive
+2. **Backward Compatibility:** Works with existing code - just don't specify tableName
+3. **Clean Database Schema:** Avoid awkward table names from URLs
+4. **Multiple Format Support:** Handles both CSV and TSV files
+
+## Example SQL Queries
+
+With custom table names:
+```sql
+-- Instead of: SELECT * FROM "country-codes"
+SELECT * FROM countries LIMIT 5;
+
+-- Instead of: SELECT * FROM "gdp"  
+SELECT * FROM gdp_data WHERE year = 2020;
+
+-- Join tables with meaningful names
+SELECT c.name, g.value 
+FROM countries c
+JOIN gdp_data g ON c.code = g.country_code;
+```

--- a/js/__tests__/csvSources.test.js
+++ b/js/__tests__/csvSources.test.js
@@ -1,0 +1,78 @@
+import { fileSources } from '../csvSources.js';
+
+describe('CSV Sources Configuration', () => {
+    test('fileSources should be an array', () => {
+        expect(Array.isArray(fileSources)).toBe(true);
+    });
+
+    test('each source should have a url property', () => {
+        fileSources.forEach(source => {
+            expect(source).toHaveProperty('url');
+            expect(typeof source.url).toBe('string');
+            expect(source.url.length).toBeGreaterThan(0);
+        });
+    });
+
+    test('tableName should be optional but a string if provided', () => {
+        fileSources.forEach(source => {
+            if (source.hasOwnProperty('tableName')) {
+                expect(typeof source.tableName).toBe('string');
+                expect(source.tableName.length).toBeGreaterThan(0);
+            }
+        });
+    });
+
+    test('type should be optional but either csv or tsv if provided', () => {
+        fileSources.forEach(source => {
+            if (source.hasOwnProperty('type')) {
+                expect(['csv', 'tsv']).toContain(source.type);
+            }
+        });
+    });
+
+    test('sources with custom table names should be properly configured', () => {
+        const sourcesWithTableNames = fileSources.filter(s => s.tableName);
+        
+        // Check that at least some sources have custom table names for testing
+        expect(sourcesWithTableNames.length).toBeGreaterThan(0);
+        
+        sourcesWithTableNames.forEach(source => {
+            expect(source.tableName).toBeTruthy();
+            expect(typeof source.tableName).toBe('string');
+        });
+    });
+
+    test('sources without table names should still have valid URLs', () => {
+        const sourcesWithoutTableNames = fileSources.filter(s => !s.tableName);
+        
+        sourcesWithoutTableNames.forEach(source => {
+            expect(source.url).toBeTruthy();
+            // URL should have a filename that can be extracted
+            const filename = source.url.substring(source.url.lastIndexOf('/') + 1);
+            expect(filename.length).toBeGreaterThan(0);
+        });
+    });
+
+    test('should have diverse source types for testing', () => {
+        const csvSources = fileSources.filter(s => !s.type || s.type === 'csv');
+        const tsvSources = fileSources.filter(s => s.type === 'tsv');
+        
+        // We should have at least one CSV source
+        expect(csvSources.length).toBeGreaterThan(0);
+        
+        // Check if we have TSV sources (optional but good for testing)
+        if (tsvSources.length > 0) {
+            expect(tsvSources[0].type).toBe('tsv');
+        }
+    });
+
+    test('source URLs should be properly formatted', () => {
+        fileSources.forEach(source => {
+            // Check that URL starts with http:// or https://
+            expect(source.url).toMatch(/^https?:\/\//);
+            
+            // Check that URL has a file extension
+            expect(source.url).toMatch(/\.(csv|tsv|txt)$/i);
+        });
+    });
+});

--- a/js/__tests__/db.test.js
+++ b/js/__tests__/db.test.js
@@ -1,0 +1,84 @@
+import { generateTableNameFromUrl } from '../db.js';
+
+describe('Database Module', () => {
+    describe('generateTableNameFromUrl', () => {
+        test('should use custom table name when provided', () => {
+            const url = 'https://example.com/data/myfile.csv';
+            const customName = 'custom_table';
+            const result = generateTableNameFromUrl(url, customName);
+            expect(result).toBe('custom_table');
+        });
+
+        test('should extract filename from URL when no custom name provided', () => {
+            const url = 'https://example.com/data/sales_data.csv';
+            const result = generateTableNameFromUrl(url);
+            expect(result).toBe('sales_data');
+        });
+
+        test('should handle special characters in custom table name', () => {
+            const url = 'https://example.com/data/file.csv';
+            const customName = 'my-table-name!@#';
+            const result = generateTableNameFromUrl(url, customName);
+            expect(result).toBe('my_table_name');
+        });
+
+        test('should handle table names starting with numbers', () => {
+            const url = 'https://example.com/123data.csv';
+            const result = generateTableNameFromUrl(url);
+            expect(result).toBe('table_123data');
+        });
+
+        test('should handle empty custom name and fall back to URL', () => {
+            const url = 'https://example.com/fallback.csv';
+            const customName = '   '; // Whitespace only
+            const result = generateTableNameFromUrl(url, customName);
+            expect(result).toBe('fallback');
+        });
+
+        test('should handle complex URLs with query parameters', () => {
+            const url = 'https://example.com/path/to/data.csv?param=value&other=123';
+            const result = generateTableNameFromUrl(url);
+            expect(result).toBe('data');
+        });
+
+        test('should handle URLs with multiple dots in filename', () => {
+            const url = 'https://example.com/my.data.file.csv';
+            const result = generateTableNameFromUrl(url);
+            expect(result).toBe('my_data_file');
+        });
+
+        test('should handle URLs ending with slash', () => {
+            const url = 'https://example.com/folder/';
+            const result = generateTableNameFromUrl(url);
+            expect(result).toBe('default_table_name');
+        });
+
+        test('should sanitize table names with consecutive special characters', () => {
+            const url = 'https://example.com/test.csv';
+            const customName = 'my---table___name';
+            const result = generateTableNameFromUrl(url, customName);
+            expect(result).toBe('my_table_name');
+        });
+
+        test('should handle numeric-only custom names', () => {
+            const url = 'https://example.com/test.csv';
+            const customName = '12345';
+            const result = generateTableNameFromUrl(url, customName);
+            expect(result).toBe('table_12345');
+        });
+
+        test('should handle single underscore as custom name', () => {
+            const url = 'https://example.com/test.csv';
+            const customName = '_';
+            const result = generateTableNameFromUrl(url, customName);
+            expect(result).toBe('default_table_name');
+        });
+
+        test('should preserve valid underscores in names', () => {
+            const url = 'https://example.com/test.csv';
+            const customName = 'valid_table_name_123';
+            const result = generateTableNameFromUrl(url, customName);
+            expect(result).toBe('valid_table_name_123');
+        });
+    });
+});

--- a/js/csvSources.js
+++ b/js/csvSources.js
@@ -1,0 +1,30 @@
+/**
+ * CSV data sources configuration.
+ * Each source can have:
+ * - url: The URL of the CSV/TSV file (required)
+ * - tableName: Optional custom table name for SQLite (defaults to filename without extension)
+ * - type: 'csv' or 'tsv' (defaults to 'csv' if not specified)
+ */
+const fileSources = [
+    {
+        url: 'https://raw.githubusercontent.com/datasets/country-codes/master/data/country-codes.csv',
+        tableName: 'countries',  // Custom table name instead of 'country_codes'
+        type: 'csv'
+    },
+    {
+        url: 'https://raw.githubusercontent.com/datasets/gdp/master/data/gdp.csv',
+        tableName: 'gdp_data',  // Custom table name
+        type: 'csv'
+    },
+    {
+        url: 'https://raw.githubusercontent.com/datasets/population/master/data/population.csv',
+        tableName: 'world_population',  // Custom table name instead of just 'population'
+        type: 'csv'
+    },
+    {
+        url: 'https://raw.githubusercontent.com/datasets/covid-19/master/data/countries-aggregated.csv'
+        // No tableName specified, will default to 'countries_aggregated' (filename without extension)
+    }
+];
+
+export { fileSources };

--- a/js/db.js
+++ b/js/db.js
@@ -1,97 +1,175 @@
-// import { parseTSV } from './tsvParser.js'; // Not needed for SQLite loading
-// import { parseCSV } from './csvParser.js'; // Not needed for SQLite loading
+import { parseTSV } from './tsvParser.js';
+import { parseCSV } from './csvParser.js';
 import { updateStatus } from './ui/statusUpdater.js';
 import { addTableToList, clearTableList } from './ui/tableListDisplay.js';
 
 let db = null;
 
-// /**
-//  * Sanitizes a given string to be a valid SQL table name.
-//  * @param {string} name - The proposed table name.
-//  * @returns {string} The sanitized table name.
-//  */
-// function sanitizeTableName(name) {
-//     // Replace non-alphanumeric characters (except underscores) with underscores
-//     let sanitizedName = name.replace(/[^a-zA-Z0-9_]/g, '_');
-//     // Condense multiple underscores into one
-//     sanitizedName = sanitizedName.replace(/_+/g, '_');
-//     // Remove leading/trailing underscores
-//     if (sanitizedName.length > 1) {
-//         sanitizedName = sanitizedName.replace(/^_+|_+$/g, '');
-//     }
-//     // Fallback for empty or invalid names
-//     if (!sanitizedName || sanitizedName === '_') {
-//         return "default_table_name";
-//     }
-//     // Ensure name starts with a letter or underscore
-//     if (/^[0-9]/.test(sanitizedName)) {
-//         sanitizedName = "table_" + sanitizedName;
-//     }
-//     if (!sanitizedName || sanitizedName === '_' || sanitizedName === 'table_') {
-//         return "default_table_name";
-//     }
-//     return sanitizedName;
-// }
+/**
+ * Sanitizes a given string to be a valid SQL table name.
+ * @param {string} name - The proposed table name.
+ * @returns {string} The sanitized table name.
+ */
+function sanitizeTableName(name) {
+    // Replace non-alphanumeric characters (except underscores) with underscores
+    let sanitizedName = name.replace(/[^a-zA-Z0-9_]/g, '_');
+    // Condense multiple underscores into one
+    sanitizedName = sanitizedName.replace(/_+/g, '_');
+    // Remove leading/trailing underscores
+    if (sanitizedName.length > 1) {
+        sanitizedName = sanitizedName.replace(/^_+|_+$/g, '');
+    }
+    // Fallback for empty or invalid names
+    if (!sanitizedName || sanitizedName === '_') {
+        return "default_table_name";
+    }
+    // Ensure name starts with a letter or underscore
+    if (/^[0-9]/.test(sanitizedName)) {
+        sanitizedName = "table_" + sanitizedName;
+    }
+    if (!sanitizedName || sanitizedName === '_' || sanitizedName === 'table_') {
+        return "default_table_name";
+    }
+    return sanitizedName;
+}
 
-// /**
-//  * Generates a sanitized table name from a URL or uses a custom name if provided.
-//  * @param {string} url - The URL to generate a table name from (used as fallback).
-//  * @param {string} [customTableName] - An optional custom table name.
-//  * @returns {string} The sanitized table name.
-//  */
-// function generateTableNameFromUrl(url, customTableName) {
-//     if (customTableName && typeof customTableName === 'string' && customTableName.trim() !== '') {
-//         return sanitizeTableName(customTableName.trim());
-//     }
-//     let filename = url.substring(url.lastIndexOf('/') + 1);
-//     filename = filename.replace(/\.[^/.]+$/, ""); // Remove file extension
-//     return sanitizeTableName(filename);
-// }
+/**
+ * Generates a sanitized table name from a URL or uses a custom name if provided.
+ * @param {string} url - The URL to generate a table name from (used as fallback).
+ * @param {string} [customTableName] - An optional custom table name.
+ * @returns {string} The sanitized table name.
+ */
+function generateTableNameFromUrl(url, customTableName) {
+    if (customTableName && typeof customTableName === 'string' && customTableName.trim() !== '') {
+        return sanitizeTableName(customTableName.trim());
+    }
+    let filename = url.substring(url.lastIndexOf('/') + 1);
+    filename = filename.replace(/\.[^/.]+$/, ""); // Remove file extension
+    return sanitizeTableName(filename);
+}
 
-// /**
-//  * Creates a table in the database.
-//  * @param {SQL.Database} dbInstance - The initialized SQL.js database instance.
-//  * @param {string} tableName - The name of the table to create.
-//  * @param {string[]} headers - Array of header strings for table columns.
-//  */
-// function createTable(dbInstance, tableName, headers) {
-//     const createTableSql = `CREATE TABLE "${tableName}" (${headers.map(h => `"${h}" TEXT`).join(', ')});`;
-//     dbInstance.run(createTableSql);
-//     updateStatus(`Table "${tableName}" created with headers: ${headers.join(', ')}.`, false, true);
-// }
+/**
+ * Creates a table in the database.
+ * @param {SQL.Database} dbInstance - The initialized SQL.js database instance.
+ * @param {string} tableName - The name of the table to create.
+ * @param {string[]} headers - Array of header strings for table columns.
+ */
+function createTable(dbInstance, tableName, headers) {
+    const createTableSql = `CREATE TABLE "${tableName}" (${headers.map(h => `"${h}" TEXT`).join(', ')});`;
+    dbInstance.run(createTableSql);
+    updateStatus(`Table "${tableName}" created with headers: ${headers.join(', ')}.`, false, true);
+}
 
-// /**
-//  * Inserts data rows into the specified table.
-//  * @async
-//  * @param {SQL.Database} dbInstance - The initialized SQL.js database instance.
-//  * @param {string} tableName - The name of the table to insert data into.
-//  * @param {string[]} headers - Array of header strings for table columns (used for validation).
-//  * @param {string[][]} dataRows - Array of data row arrays (pre-parsed values).
-//  */
-// async function insertData(dbInstance, tableName, headers, dataRows) {
-//     const placeholders = headers.map(() => '?').join(', ');
-//     const insertSql = `INSERT INTO "${tableName}" VALUES (${placeholders});`;
-//     const stmt = dbInstance.prepare(insertSql);
-//     dbInstance.run('BEGIN TRANSACTION;');
-//     try {
-//         dataRows.forEach(row => {
-//             if (row.length === headers.length) {
-//                 stmt.run(row);
-//             } else {
-//                 console.warn('Skipping malformed row (header/value count mismatch):', row.join(','));
-//             }
-//         });
-//         dbInstance.run('COMMIT;');
-//         updateStatus(`Inserted ${dataRows.length} rows into "${tableName}".`, false, true);
-//     } catch (transactionError) {
-//         dbInstance.run('ROLLBACK;');
-//         console.error("Transaction error during data insertion:", transactionError);
-//         updateStatus(`Transaction error: ${transactionError.message}`, true);
-//         throw transactionError;
-//     } finally {
-//         stmt.free();
-//     }
-// }
+/**
+ * Inserts data rows into the specified table.
+ * @async
+ * @param {SQL.Database} dbInstance - The initialized SQL.js database instance.
+ * @param {string} tableName - The name of the table to insert data into.
+ * @param {string[]} headers - Array of header strings for table columns (used for validation).
+ * @param {string[][]} dataRows - Array of data row arrays (pre-parsed values).
+ */
+async function insertData(dbInstance, tableName, headers, dataRows) {
+    const placeholders = headers.map(() => '?').join(', ');
+    const insertSql = `INSERT INTO "${tableName}" VALUES (${placeholders});`;
+    const stmt = dbInstance.prepare(insertSql);
+    dbInstance.run('BEGIN TRANSACTION;');
+    try {
+        dataRows.forEach(row => {
+            if (row.length === headers.length) {
+                stmt.run(row);
+            } else {
+                console.warn('Skipping malformed row (header/value count mismatch):', row.join(','));
+            }
+        });
+        dbInstance.run('COMMIT;');
+        updateStatus(`Inserted ${dataRows.length} rows into "${tableName}".`, false, true);
+    } catch (transactionError) {
+        dbInstance.run('ROLLBACK;');
+        console.error("Transaction error during data insertion:", transactionError);
+        updateStatus(`Transaction error: ${transactionError.message}`, true);
+        throw transactionError;
+    } finally {
+        stmt.free();
+    }
+}
+
+/**
+ * Loads CSV/TSV data from a source configuration.
+ * @async
+ * @param {SQL.Database} dbInstance - The initialized SQL.js database instance.
+ * @param {Object} source - The source configuration object.
+ * @param {string} source.url - The URL of the CSV/TSV file.
+ * @param {string} [source.tableName] - Optional custom table name.
+ * @param {string} [source.type] - The file type ('csv' or 'tsv', defaults to 'csv').
+ */
+async function loadCSVSource(dbInstance, source) {
+    const { url, tableName, type = 'csv' } = source;
+    
+    try {
+        updateStatus(`Fetching ${type.toUpperCase()} from ${url}...`, false, true);
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status} while fetching ${url}`);
+        }
+        const text = await response.text();
+        updateStatus(`${type.toUpperCase()} fetched successfully from ${url}.`, false, true);
+        
+        // Parse the CSV/TSV data
+        const { headers, dataRows } = type === 'tsv' ? parseTSV(text) : parseCSV(text);
+        
+        // Generate table name
+        const finalTableName = generateTableNameFromUrl(url, tableName);
+        
+        // Create table and insert data
+        createTable(dbInstance, finalTableName, headers);
+        await insertData(dbInstance, finalTableName, headers, dataRows);
+        
+        // Add table to the UI list
+        addTableToList(finalTableName);
+        
+        updateStatus(`Successfully loaded ${dataRows.length} rows into table "${finalTableName}".`, false, true);
+    } catch (error) {
+        const errorMessage = `Failed to load ${type.toUpperCase()} from ${url}: ${error.message}`;
+        updateStatus(errorMessage, true);
+        console.error("CSV/TSV loading error:", error);
+        throw error;
+    }
+}
+
+/**
+ * Initializes the SQL.js database from CSV sources.
+ * @async
+ * @param {Array} sources - Array of source configurations.
+ * @returns {Promise<SQL.Database>} The initialized SQL.js database instance.
+ */
+async function initializeDatabaseFromCSV(sources) {
+    try {
+        const SQL = await initSqlJs({
+            locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.3/${file}`
+        });
+        updateStatus('SQL.js initialized.');
+        
+        // Create a new empty database
+        db = new SQL.Database();
+        updateStatus('Empty database created.', false, true);
+        
+        clearTableList(); // Clear the list before populating
+        
+        // Load each CSV source
+        for (const source of sources) {
+            await loadCSVSource(db, source);
+        }
+        
+        updateStatus('All CSV sources loaded. Database ready for queries!', false, true);
+        return db;
+        
+    } catch (error) {
+        const errorMessage = `Database initialization from CSV failed: ${error.message}`;
+        updateStatus(errorMessage, true);
+        console.error("Database initialization error details:", error);
+        throw error;
+    }
+}
 
 /**
  * Initializes the SQL.js database from a given SQLite database URL.
@@ -142,7 +220,6 @@ async function initializeDatabase(dbUrl) {
     }
 }
 
-// Export initializeDatabase and the db instance.
-// Other functions like createTable, insertData, generateTableNameFromUrl are no longer needed for this approach.
-export { initializeDatabase };
+// Export functions and the db instance.
+export { initializeDatabase, initializeDatabaseFromCSV, generateTableNameFromUrl };
 export { db };

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
-import { initializeDatabase, db } from './db.js'; // Import db, removed generateTableNameFromUrl as it's no longer used here
+import { initializeDatabase, initializeDatabaseFromCSV, db } from './db.js';
 import { executeQuery } from './query.js';
-// import { fileSources } from './csvSources.js'; // Removed: No longer loading from CSV sources defined here
+import { fileSources } from './csvSources.js';
 import { initializeCopyButton } from './ui/copyButton.js';
 import { startTimer, stopTimer, displayTime } from './ui/timer.js';
 
@@ -47,11 +47,20 @@ initializeCopyButton();
 
 startTimer();
 
+// Configuration: Set to 'sqlite' to load from SQLite DB, or 'csv' to load from CSV sources
+const dataSourceMode = 'csv'; // Change this to 'sqlite' to use the SQLite database
+
+// SQLite database URL
 const dbUrl = "https://github.com/aewshopping/history-books-lite/raw/refs/heads/main/data.db";
 
-initializeDatabase(dbUrl)
+// Initialize database based on mode
+const initPromise = dataSourceMode === 'csv' 
+    ? initializeDatabaseFromCSV(fileSources)
+    : initializeDatabase(dbUrl);
+
+initPromise
     .then(() => {
-        // Database is initialized from the .db URL.
+        // Database is initialized.
         // Set an initial query.
         try {
             const sqlInput = document.getElementById('sql-input');

--- a/test-csv-sources.html
+++ b/test-csv-sources.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test CSV Sources with Custom Table Names</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.3/sql-wasm.js"></script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>CSV Sources Test with Custom Table Names</h1>
+        <div id="timer"></div>
+        <div id="status">Initializing SQL.js...</div>
+
+        <h2>Data Source Configuration</h2>
+        <pre id="source-config" style="background: #f4f4f4; padding: 10px; border-radius: 5px;">
+Loading configuration...
+        </pre>
+
+        <h2>Query Data</h2>
+        <p>Enter SQL query (e.g., SELECT * FROM your_table_name LIMIT 5):</p>
+        <textarea id="sql-input">SELECT name FROM sqlite_master WHERE type='table';</textarea>
+        <button id="execute-button">Execute Query</button>
+
+        <h3>Loaded Tables:</h3>
+        <ul id="loaded-tables-list"></ul>
+
+        <button id="download-db-button">Download Database</button>
+
+        <h2>Results</h2>
+        <div id="results">
+            <button id="copy-button" class="copy-button">Copy</button>
+            <p>Query results will appear here.</p>
+        </div>
+    </div>
+
+    <script type="module">
+        // Import necessary modules
+        import { initializeDatabaseFromCSV, db } from './js/db.js';
+        import { executeQuery } from './js/query.js';
+        import { initializeCopyButton } from './js/ui/copyButton.js';
+        import { startTimer, stopTimer, displayTime } from './js/ui/timer.js';
+
+        // Define test CSV sources with custom table names
+        const testSources = [
+            {
+                url: 'https://raw.githubusercontent.com/datasets/country-codes/master/data/country-codes.csv',
+                tableName: 'countries',  // Custom table name instead of 'country-codes'
+                type: 'csv'
+            },
+            {
+                url: 'https://raw.githubusercontent.com/datasets/airport-codes/master/data/airport-codes.csv',
+                tableName: 'airports',  // Custom table name instead of 'airport-codes'
+                type: 'csv'
+            },
+            {
+                url: 'https://raw.githubusercontent.com/datasets/world-cities/master/data/world-cities.csv',
+                // No custom table name - will default to 'world_cities'
+                type: 'csv'
+            }
+        ];
+
+        // Display the configuration
+        document.getElementById('source-config').textContent = JSON.stringify(testSources, null, 2);
+
+        // Initialize UI components
+        const executeButton = document.getElementById('execute-button');
+        const downloadDbButton = document.getElementById('download-db-button');
+
+        if (executeButton) {
+            executeButton.addEventListener('click', executeQuery);
+        }
+
+        if (downloadDbButton) {
+            downloadDbButton.addEventListener('click', () => {
+                if (db) {
+                    try {
+                        const data = db.export();
+                        const blob = new Blob([data], { type: 'application/octet-stream' });
+                        const url = URL.createObjectURL(blob);
+                        const a = document.createElement('a');
+                        a.href = url;
+                        a.download = 'database.db';
+                        document.body.appendChild(a);
+                        a.click();
+                        document.body.removeChild(a);
+                        URL.revokeObjectURL(url);
+                        console.log("Database download initiated.");
+                    } catch (e) {
+                        console.error("Error exporting database:", e);
+                        alert("Error exporting database. See console for details.");
+                    }
+                } else {
+                    console.error("Database not initialized. Cannot download.");
+                    alert("Database not yet initialized. Please wait or try reloading.");
+                }
+            });
+        }
+
+        initializeCopyButton();
+        startTimer();
+
+        // Initialize database from CSV sources
+        initializeDatabaseFromCSV(testSources)
+            .then(() => {
+                console.log("Database initialized from CSV sources.");
+                
+                // Update the initial query to show all tables
+                const sqlInput = document.getElementById('sql-input');
+                if (sqlInput) {
+                    sqlInput.value = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;";
+                }
+                
+                executeQuery();
+                stopTimer();
+                displayTime();
+            })
+            .catch(error => {
+                console.error("Failed to initialize the application:", error);
+                const statusDiv = document.getElementById('status');
+                if (statusDiv) {
+                    statusDiv.innerHTML = `<p class="error">Application initialization failed: ${error.message}</p>`;
+                }
+                stopTimer();
+                displayTime();
+            });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add support for optional custom table names when loading CSV/TSV data to SQLite, improving schema control and query readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-3659b4c1-f040-468b-880f-ad0963393ebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3659b4c1-f040-468b-880f-ad0963393ebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

